### PR TITLE
Only check puppet's version if USE_PUPPET_FUTURE_PARSER=enabled

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -49,9 +49,13 @@ if [[ -e ${subhook_root}/config.cfg ]] ; then
 fi
 
 # Only puppet 3.2.1 - 3.8 support "--parser future" option.
-case $(puppet --version) in
-  4*) USE_PUPPET_FUTURE_PARSER="disabled" ;;
-esac
+if [[ "$USE_PUPPET_FUTURE_PARSER" == "enabled" ]]; then
+  case $(puppet --version) in
+    3.2.[1-9]) ;;
+    3.[3-8]*)  ;;
+    *) USE_PUPPET_FUTURE_PARSER="disabled" ;;
+  esac
+fi
 
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")

--- a/pre-receive
+++ b/pre-receive
@@ -44,9 +44,13 @@ if [[ $UNSET_RUBY_ENV == "enabled" ]] ; then
 fi
 
 # Only puppet 3.2.1 - 3.8 support "--parser future" option.
-case $(puppet --version) in
-  4*) USE_PUPPET_FUTURE_PARSER="disabled" ;;
-esac
+if [[ "$USE_PUPPET_FUTURE_PARSER" == "enabled" ]]; then
+  case $(puppet --version) in
+    3.2.[1-9]) ;;
+    3.[3-8]*)  ;;
+    *) USE_PUPPET_FUTURE_PARSER="disabled" ;;
+  esac
+fi
 
 while read -r oldrev newrev refname; do
     git archive "$newrev" | tar x -C "$tmptree"


### PR DESCRIPTION
This small optimization cuts the hook time in half when the future
parser is disabled (default).