### PR TITLE
Add /opt/puppetlabs/puppet/bin to PATH

### DIFF
--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -6,3 +6,4 @@ CHECK_RSPEC="enabled" # enabled or disabled
 export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-140chars-check"
 export PUPPET_LINT_FAIL_ON_WARNINGS="true" # Set the puppet-lint option --fail-on-warnings
 UNSET_RUBY_ENV="enabled" # enabled or disabled. Required for Gitlab.
+PATH="$PATH:/opt/puppetlabs/puppet/bin"


### PR DESCRIPTION
The all-in-one puppet-agent package ships /opt/puppetlabs/puppet/bin/gem
that install gems into /opt/puppetlabs/puppet/bin.