### PR TITLE
Run yaml checks when yamllint or ruby is available

### DIFF
--- a/commit_hooks/yaml_syntax_check.sh
+++ b/commit_hooks/yaml_syntax_check.sh
@@ -22,8 +22,7 @@ fi
 
 # Check YAML file syntax
 $ERRORS_ONLY || echo -e "$(tput setaf 6)Checking yaml syntax for $module_path...$(tput sgr0)"
-if test -e /usr/bin/yamllint
-then
+if type yamllint > /dev/null 2>&1; then
   yamllint $YAMLLINT_CONFIG -f parsable $1 &> "$error_msg"
 else
   ruby -e "require 'yaml'; YAML.parse(File.open('$1'))" 2> "$error_msg" > /dev/null

--- a/pre-commit
+++ b/pre-commit
@@ -110,15 +110,6 @@ for changedfile in $files_to_check; do
             echo "erb not installed. Skipping erb template checks..."
         fi
 
-        #check hiera data (yaml/yml/eyaml/eyml) syntax
-        if echo "$changedfile" | grep -iq '\.e\?ya\?ml$'; then
-            ${subhook_root}/yaml_syntax_check.sh "$changedfile"
-            RC=$?
-            if [[ "$RC" -ne 0 ]]; then
-                failures=$((failures + 1))
-            fi
-        fi
-
         #check json (i.e. metadata.json) syntax
         if echo "$changedfile" | grep -iq '\.json$'; then
             ${subhook_root}/json_syntax_check.sh "$changedfile"
@@ -128,7 +119,20 @@ for changedfile in $files_to_check; do
             fi
         fi
     else
-        echo "ruby not installed. Skipping erb/yaml/json checks..."
+        echo "ruby not installed. Skipping erb/json checks..."
+    fi
+
+    if type yamllint >/dev/null 2>&1 || type ruby >/dev/null 2>&1; then
+        #check hiera data (yaml/yml/eyaml/eyml) syntax
+        if echo "$changedfile" | grep -iq '\.e\?ya\?ml$'; then
+            ${subhook_root}/yaml_syntax_check.sh "$changedfile"
+            RC=$?
+            if [[ "$RC" -ne 0 ]]; then
+                failures=$((failures + 1))
+            fi
+        fi
+    else
+        echo "yamllint nor ruby not installed. Skipping yaml checks..."
     fi
 
     #puppet manifest styleguide compliance

--- a/pre-receive
+++ b/pre-receive
@@ -116,15 +116,6 @@ while read -r oldrev newrev refname; do
                 echo "erb not installed. Skipping erb template checks..."
             fi
 
-            #check hiera data (yaml/yml) syntax
-            if [[ $(echo "$changedfile" | grep -q '\.*\.yaml$\|\.*\.yml$'; echo $?) -eq 0 ]]; then
-                ${subhook_root}/yaml_syntax_check.sh "$tmpmodule" "${tmptree}/"
-                RC=$?
-                if [[ $RC -ne 0 ]]; then
-                  failures=$((failures + 1))
-                fi
-            fi
-
             #check hiera data (json) syntax
             if [[ $(echo "$changedfile" | grep -q '\.*\.json$'; echo $?) -eq 0 ]]; then
                 ${subhook_root}/json_syntax_check.sh "$tmpmodule" "${tmptree}/"
@@ -134,7 +125,20 @@ while read -r oldrev newrev refname; do
                 fi
             fi
         else
-            echo "ruby not installed. Skipping erb/yaml/ruby checks..."
+            echo "ruby not installed. Skipping ruby/erb/json checks..."
+        fi
+
+        if type yamllint >/dev/null 2>&1 || type ruby >/dev/null 2>&1; then
+            #check hiera data (yaml/yml/eyaml/eyml) syntax
+            if echo "$changedfile" | grep -iq '\.e\?ya\?ml$'; then
+                ${subhook_root}/yaml_syntax_check.sh "$tmpmodule" "${tmptree}/"
+                RC=$?
+                if [[ $RC -ne 0 ]]; then
+                  failures=$((failures + 1))
+                fi
+            fi
+        else
+            echo "yamllint nor ruby not installed. Skipping yaml checks..."
         fi
 
         #puppet manifest styleguide compliance


### PR DESCRIPTION
Prior to this, ruby was required to try to lint yaml files even if yamllint was used for the actual checks.