### PR TITLE
be more permissive by default

### DIFF
--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -5,6 +5,6 @@ CHECK_INITIAL_COMMIT="disabled" # enabled or disabled
 CHECK_RSPEC="enabled" # enabled or disabled
 CHECK_R10K="enabled" # enabled or disabled
 export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-140chars-check"
-export PUPPET_LINT_FAIL_ON_WARNINGS="true" # Set the puppet-lint option --fail-on-warnings
+export PUPPET_LINT_FAIL_ON_WARNINGS="false" # Set the puppet-lint option --fail-on-warnings
 UNSET_RUBY_ENV="enabled" # enabled or disabled. Required for Gitlab.
 PATH="$PATH:/opt/puppetlabs/puppet/bin"


### PR DESCRIPTION
We stop failing on docs test by default, and avoid failing on linting warnings.

This is a matter of policy I guess, but since there's no way to modify the config short of committing to the repository, I figured I would share my own configurations. Ideally, those kind of site-local policies could be established without having to edit the worktree...